### PR TITLE
fixing base=1 case

### DIFF
--- a/num2tex/__init__.py
+++ b/num2tex/__init__.py
@@ -28,6 +28,7 @@ class num2tex(str):
         self.num = num
         self.precision = precision
         self.format_spec = format_spec
+        self.exp_only_format = '10^{}'
         self.exp_format = option_exp_format if exp_format is None else exp_format
         if self.exp_format == 'times':
             self.exp_format = '\\times 10^{}'
@@ -67,10 +68,11 @@ class num2tex(str):
             num_string = str.format(format_spec_braced,float(self))
         if 'e' in num_string:
             base, exponent = num_string.split('e')
-            exp = str.format((str.format(self.exp_format,'{{{}}}')),int(exponent))
             if base == '1' and self.display_singleton is False:
+                exp = str.format((str.format(self.exp_only_format, '{{{}}}')), int(exponent))
                 return str.format(r'{0}',exp)
             else:
+                exp = str.format((str.format(self.exp_format, '{{{}}}')), int(exponent))
                 return str.format(r'{0} {1}',base,exp)
         else:
             return num_string

--- a/num2tex/tests/test_num2tex.py
+++ b/num2tex/tests/test_num2tex.py
@@ -62,6 +62,11 @@ nan_tester = inputAndOutput(
         value = 1.7976931348623159e+308-1.7976931348623159e+308,
         output_str = '\\mathrm{NaN}')
 
+one_tester = inputAndOutput(
+        value = 10**-6,
+        output_str = '10^{-6}'
+    )
+
 class TestNum2tex(unittest.TestCase):
     def test_methods(self):
         for outputType in ['__str__','__repr__','_repr_latex_']:


### PR DESCRIPTION
For round numbers (e.g. 10**-6), num2tex would produce `\times 10^{-6}`, which is not desired. Now it will produce `10^{-6}`. This addresses an open issue in the repo.